### PR TITLE
BACKEND-15: Константы логгера вынесены в общий конфиг

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -11,6 +11,9 @@ from pydantic_settings import (
 BASE_DIR = Path(__file__).parent.parent.parent
 TOML_SETTINGS_PATH = BASE_DIR / "config.toml"
 
+LOG_DIR = BASE_DIR / "logs"
+LOG_FILE = LOG_DIR / "app.log"
+
 
 class App(BaseModel):
     """Основные параметры приложения."""

--- a/src/core/logger/config.py
+++ b/src/core/logger/config.py
@@ -6,8 +6,7 @@ from rich.console import Console
 from rich.highlighter import Highlighter
 from rich.logging import RichHandler
 
-LOG_DIR = "logs"
-LOG_FILE = "app.log"
+from src.config.config import LOG_DIR, LOG_FILE
 
 
 class LevelHighlighter(Highlighter):


### PR DESCRIPTION
Константы LOG_FILE и LOG_DIR перенесены из src/core/logger/config.py в src/config/config.py. Closes #15 