### PR TITLE
BACKEND-51: Добавлено автоматическое формирование seq и key

### DIFF
--- a/src/repository/sql/project_repo.py
+++ b/src/repository/sql/project_repo.py
@@ -42,6 +42,11 @@ class ProjectRepositoryImpl(BaseRepository[Project]):
         items = await Project.get_all(self.session)
         return [map_model(i, ProjectDTO) for i in items]
 
+    async def get_key_by_id(self, project_id: uuid.UUID) -> str | None:
+        stmt = select(Project.key).where(Project.id == project_id)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
     async def get_list(
         self, search: str | None, limit: int, offset: int
     ) -> tuple[list[ProjectDTO], int]:

--- a/src/repository/sql/task_sequence_repo.py
+++ b/src/repository/sql/task_sequence_repo.py
@@ -1,5 +1,6 @@
 import uuid
 
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.db.models import TaskSequence
@@ -40,3 +41,21 @@ class TaskSequenceRepositoryImpl(BaseRepository[TaskSequence]):
     async def get_all(self) -> list[TaskSequenceDTO]:
         items = await TaskSequence.get_all(self.session)
         return [map_model(i, TaskSequenceDTO) for i in items]
+
+    async def reserve_next_seq(self, project_id: uuid.UUID) -> int:
+        stmt = (
+            update(TaskSequence)
+            .where(TaskSequence.project_id == project_id)
+            .values(next_seq=TaskSequence.next_seq + 1)
+            .returning(TaskSequence.next_seq - 1)
+        )
+
+        result = await self.session.execute(stmt)
+        seq = result.scalar_one_or_none()
+
+        if seq is None:
+            item = TaskSequence(project_id=project_id, next_seq=2)
+            await item.save(self.session)
+            return 1
+
+        return seq

--- a/src/services/production/task_service.py
+++ b/src/services/production/task_service.py
@@ -17,6 +17,14 @@ class TaskServiceImpl(BaseService[TaskDTO]):
     async def create(self, data: dict) -> TaskDTO:
         data.pop("tag_ids", None)
         # TODO: обновление таблицы task_tag
+
+        project_id: UUID = data["project_id"]
+        project_key = await self.store.project_repo().get_key_by_id(project_id)
+        seq = await self.store.task_sequence_repo().reserve_next_seq(project_id)
+
+        data["seq"] = seq
+        data["key"] = f"{project_key}-{seq}"
+
         item = await self.store.task_repo().create(data)
         return item
 


### PR DESCRIPTION
Добавлено автоматическое формирование seq и key при создании task. Для этого добавлен метод get_key_by_id в project_repo для получения ключа проекта и метод reserve_next_seq в task_sequence_repo для одновременного получения и увеличения next_seq. Closes: #51