### PR TITLE
BACKEND-55: Добавлена проверка связанных задач при удалении статуса

### DIFF
--- a/src/apps/statuses/api/v1/endpoints/statuses.py
+++ b/src/apps/statuses/api/v1/endpoints/statuses.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from src.core.dependencies import get_service_manager
 from src.core.utils import map_model
@@ -33,10 +33,12 @@ async def update_status(
     summary="Удалить статус",
     description=(
         "Удаляет статус по указанному идентификатору. При наличии связанных задач "
-        "возвращает ошибку 400 или 409. При успешном выполнении возвращает статус 204."
+        "возвращает ошибку 409. При успешном выполнении возвращает статус 204."
     ),
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def delete_status(status_id: UUID, service_manager: Service = Depends(get_service_manager)):
-    # TODO: проверить наличие связанных задач и вернуть 409, если они есть
+    if await service_manager.status_service().has_related_tasks(status_id):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT)
+
     await service_manager.status_service().delete(status_id)

--- a/src/repository/sql/task_repo.py
+++ b/src/repository/sql/task_repo.py
@@ -43,6 +43,11 @@ class TaskRepositoryImpl(BaseRepository[Task]):
         items = await Task.get_all(self.session)
         return [map_model(i, TaskDTO) for i in items]
 
+    async def exists_by_status(self, status_id: uuid.UUID) -> bool:
+        stmt = select(Task.id).where(Task.status_id == status_id).limit(1)
+        result = await self.session.execute(stmt)
+        return result.scalars().first() is not None
+
     async def get_all_by_project(
         self, project_id: uuid.UUID, filters: dict, limit: int, offset: int, sort: str
     ) -> tuple[list[TaskDTO], int]:

--- a/src/services/production/status_service.py
+++ b/src/services/production/status_service.py
@@ -29,6 +29,9 @@ class StatusServiceImpl(BaseService[StatusDTO]):
         items = await self.store.status_repo().get_all()
         return items
 
+    async def has_related_tasks(self, status_id: UUID) -> bool:
+        return await self.store.task_repo().exists_by_status(status_id)
+
     async def get_all_by_project(self, project_id: UUID) -> list[StatusDTO]:
         items = await self.store.status_repo().get_all_by_project(project_id)
         return items


### PR DESCRIPTION
При удалении статуса теперь проверяется наличие связанных задач, и, если они есть, возвращается HTTP 409 Conflict. Для этого добавлен метод has_related_tasks в status_service и метод exists_by_status в task_repo. Closes: #55 
